### PR TITLE
Exclude LAN traffic

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -50,6 +50,7 @@ type Interface struct {
 	PreDown    string
 	PostDown   string
 	TableOff   bool
+	ExcludeLAN bool
 }
 
 type Peer struct {

--- a/conf/parser.go
+++ b/conf/parser.go
@@ -118,6 +118,13 @@ func parseTableOff(s string) (bool, error) {
 	return false, err
 }
 
+func parseLAN(s string) (bool, error) {
+	if s == "exclude" {
+		return true, nil
+	}
+	return false, nil
+}
+
 func parseKeyBase64(s string) (*Key, error) {
 	k, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
@@ -255,6 +262,12 @@ func FromWgQuick(s, name string) (*Config, error) {
 					return nil, err
 				}
 				conf.Interface.TableOff = tableOff
+			case "lan":
+				excludeLAN, err := parseLAN(val)
+				if err != nil {
+					return nil, err
+				}
+				conf.Interface.ExcludeLAN = excludeLAN
 			default:
 				return nil, &ParseError{l18n.Sprintf("Invalid key for [Interface] section"), key}
 			}

--- a/conf/parser.go
+++ b/conf/parser.go
@@ -119,7 +119,7 @@ func parseTableOff(s string) (bool, error) {
 }
 
 func parseLAN(s string) (bool, error) {
-	if s == "exclude" {
+	if s == "on" {
 		return true, nil
 	}
 	return false, nil
@@ -262,7 +262,7 @@ func FromWgQuick(s, name string) (*Config, error) {
 					return nil, err
 				}
 				conf.Interface.TableOff = tableOff
-			case "lan":
+			case "excludelan":
 				excludeLAN, err := parseLAN(val)
 				if err != nil {
 					return nil, err

--- a/tunnel/addressconfig.go
+++ b/tunnel/addressconfig.go
@@ -154,5 +154,5 @@ func enableFirewall(conf *conf.Config, luid winipcfg.LUID) error {
 		}
 	}
 	log.Println("Enabling firewall rules")
-	return firewall.EnableFirewall(uint64(luid), doNotRestrict, conf.Interface.DNS)
+	return firewall.EnableFirewall(uint64(luid), doNotRestrict, conf.Interface.DNS, conf.Interface.ExcludeLAN)
 }

--- a/tunnel/firewall/blocker.go
+++ b/tunnel/firewall/blocker.go
@@ -99,7 +99,7 @@ func registerBaseObjects(session uintptr) (*baseObjects, error) {
 	return bo, nil
 }
 
-func EnableFirewall(luid uint64, doNotRestrict bool, restrictToDNSServers []netip.Addr) error {
+func EnableFirewall(luid uint64, doNotRestrict bool, restrictToDNSServers []netip.Addr, excludeLAN bool) error {
 	if wfpSession != 0 {
 		return errors.New("The firewall has already been enabled")
 	}
@@ -128,9 +128,11 @@ func EnableFirewall(luid uint64, doNotRestrict bool, restrictToDNSServers []neti
 				}
 			}
 
-			err = permitLocalNetworksIPv4(session, baseObjects, 12)
-			if err != nil {
-				return wrapErr(err)
+			if excludeLAN {
+				err = permitLocalNetworksIPv4(session, baseObjects, 12)
+				if err != nil {
+					return wrapErr(err)
+				}
 			}
 
 			err = permitLoopback(session, baseObjects, 13)

--- a/tunnel/firewall/blocker.go
+++ b/tunnel/firewall/blocker.go
@@ -15,9 +15,7 @@ import (
 
 type wfpObjectInstaller func(uintptr) error
 
-//
 // Fundamental WireGuard specific WFP objects.
-//
 type baseObjects struct {
 	provider windows.GUID
 	filters  windows.GUID
@@ -128,6 +126,11 @@ func EnableFirewall(luid uint64, doNotRestrict bool, restrictToDNSServers []neti
 				if err != nil {
 					return wrapErr(err)
 				}
+			}
+
+			err = permitLocalNetworksIPv4(session, baseObjects, 12)
+			if err != nil {
+				return wrapErr(err)
 			}
 
 			err = permitLoopback(session, baseObjects, 13)

--- a/tunnel/firewall/network_address.go
+++ b/tunnel/firewall/network_address.go
@@ -1,0 +1,32 @@
+package firewall
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"net/netip"
+)
+
+type networkAddress struct {
+	ip   string
+	mask string
+}
+
+func (addr *networkAddress) cidr() string {
+	mask := net.IPMask(net.ParseIP(addr.mask).To4())
+	prefixSize, _ := mask.Size()
+
+	return fmt.Sprint(addr.ip, "/", prefixSize)
+}
+
+func (addr *networkAddress) wtFwpV4AddrAndMask() wtFwpV4AddrAndMask {
+	return wtFwpV4AddrAndMask{
+		addr: ipV4ToUint32(addr.ip),
+		mask: ipV4ToUint32(addr.mask),
+	}
+}
+
+func ipV4ToUint32(ip string) uint32 {
+	addr := netip.MustParseAddr(ip).As4()
+	return binary.BigEndian.Uint32(addr[:])
+}

--- a/tunnel/firewall/rules.go
+++ b/tunnel/firewall/rules.go
@@ -379,7 +379,7 @@ func permitLocalNetworksIPv4(session uintptr, baseObjects *baseObjects, weight u
 			conditions := []wtFwpmFilterCondition0{condition}
 
 			displayData, err := createWtFwpmDisplayData0(
-				fmt.Sprint("Permit outbound IPv4 traffic for local network", network.cidr()),
+				fmt.Sprint("Permit outbound IPv4 traffic for local network ", network.cidr()),
 				"",
 			)
 			if err != nil {

--- a/tunnel/firewall/rules.go
+++ b/tunnel/firewall/rules.go
@@ -8,6 +8,7 @@ package firewall
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"net/netip"
 	"runtime"
 	"unsafe"
@@ -15,9 +16,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-//
 // Known addresses.
-//
 var (
 	linkLocal = wtFwpV6AddrAndMask{[16]uint8{0xfe, 0x80}, 10}
 
@@ -348,6 +347,64 @@ func permitLoopback(session uintptr, baseObjects *baseObjects, weight uint8) err
 		err = fwpmFilterAdd0(session, &filter, 0, &filterID)
 		if err != nil {
 			return wrapErr(err)
+		}
+	}
+
+	return nil
+}
+
+func permitLocalNetworksIPv4(session uintptr, baseObjects *baseObjects, weight uint8) error {
+	// #1 permit outbound traffic to local network
+	{
+		localNetworks := []networkAddress{
+			{"10.0.0.0", "255.0.0.0"},
+			{"169.254.0.0", "255.255.0.0"},
+			{"172.16.0.0", "255.240.0.0"},
+			{"192.168.0.0", "255.255.0.0"},
+			{"224.0.0.0", "240.0.0.0"},
+			{"255.255.255.255", "255.255.255.255"},
+		}
+
+		for _, network := range localNetworks {
+			addrAndMask := network.wtFwpV4AddrAndMask()
+			condValue := wtFwpConditionValue0{
+				_type: cFWP_V4_ADDR_MASK,
+				value: uintptr(unsafe.Pointer(&addrAndMask)),
+			}
+			condition := wtFwpmFilterCondition0{
+				fieldKey:       cFWPM_CONDITION_IP_REMOTE_ADDRESS,
+				matchType:      cFWP_MATCH_EQUAL,
+				conditionValue: condValue,
+			}
+			conditions := []wtFwpmFilterCondition0{condition}
+
+			displayData, err := createWtFwpmDisplayData0(
+				fmt.Sprint("Permit outbound IPv4 traffic for local network", network.cidr()),
+				"",
+			)
+			if err != nil {
+				return wrapErr(err)
+			}
+
+			filter := wtFwpmFilter0{
+				displayData:         *displayData,
+				providerKey:         &baseObjects.provider,
+				layerKey:            cFWPM_LAYER_ALE_AUTH_CONNECT_V4,
+				subLayerKey:         baseObjects.filters,
+				weight:              filterWeight(weight),
+				numFilterConditions: uint32(len(conditions)),
+				filterCondition:     (*wtFwpmFilterCondition0)(unsafe.Pointer(&conditions[0])),
+				action: wtFwpmAction0{
+					_type: cFWP_ACTION_PERMIT,
+				},
+			}
+
+			filterID := uint64(0)
+
+			err = fwpmFilterAdd0(session, &filter, 0, &filterID)
+			if err != nil {
+				return wrapErr(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1205188905467769/f

**Description**:
Permits LAN traffic to go outside of the tunnel in killswitch mode if the `LAN = exclude` config is set.

**Steps to test this PR**:
1.
2.
